### PR TITLE
screenshots proof of concept

### DIFF
--- a/02-Diving-In.Rmd
+++ b/02-Diving-In.Rmd
@@ -45,3 +45,21 @@ webshot2::webshot("https://ropensci.org/blog/2019/10/21/rmangal/",
                              )
                  )
 ```
+
+* Author page with a frame
+
+
+```{r authorpageframed, cache = TRUE}
+library("magrittr")
+webshot2::webshot("https://ropensci.org/authors/kelly-obriant/",
+                  selector = "section.author",
+                  expand = c(50, # top
+                             0, # right
+                             0, # bottom
+                             0 #left
+                             )
+                  ) %>%
+  magick::image_read() %>%
+  magick::image_frame(color = "#1f58a3", geometry = "5x5")
+
+```

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ License: MIT + file LICENSE
 Imports: 
     bookdown,
     webshot2,
-    curl
+    curl,
+    magick
 Remotes:
     rstudio/webshot2
 Encoding: UTF-8


### PR DESCRIPTION
Pros of programmatic screenshots:
* easier to re-render with a different viewer width etc.
* easier to switch URLs and get footnotes of another post.
* should be easier to re-render after a re-design (with tweaks in the design changed CSS selectors though).
* _I_ prefer to fiddle with code than the not smooth workflow of taking a screenshot, saving it etc.
* If we want we could add a coloured frame around all screenshots easily using `magick`.

Cons:
* I admit it's less intuitive!
* One needs to run the code to see the screenshot.

How-to: (Better shown during a call to screen share)
To get the CSS selector I want to I use the web developer console (in Firefox but it's the same in Chrome) and click on "add CSS rule" and the rule empty field starts with a CSS selector I can copy-paste.
Play a bit with the `expand` argument, and with `delay` if the thing screenshot uses an external library that could be loaded after a while.