### PR TITLE
edits to checklists and appendix only

### DIFF
--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -32,7 +32,8 @@ show_template("author-file-template.md", lang = "yaml")
 
 # Author checklist for a post about a peer-reviewed package
 
-Copy this checklist into the first comment on your pull request. 
+Copy this checklist into the first comment on your pull request.
+You can hover over the top-right corner of the template to make a copy-paste button appear.
 
 ```{r checklistpkg2, echo = FALSE}
 show_checklist(c("submission-checklist.csv", "submission-checklist-peer-reviewed-pkg.csv"))
@@ -41,6 +42,7 @@ show_checklist(c("submission-checklist.csv", "submission-checklist-peer-reviewed
 # Author checklist for any other post
 
 Copy this checklist into the first comment on your pull request. 
+You can hover over the top-right corner of the template to make a copy-paste button appear.
 
 ```{r checklistother2, echo = FALSE}
 show_checklist("submission-checklist.csv")
@@ -49,6 +51,7 @@ show_checklist("submission-checklist.csv")
 # Editor checklist for a post about a peer-reviewed package
 
 Copy this checklist to your GitHub review summary.
+You can hover over the top-right corner of the template to make a copy-paste button appear.
 
 ```{r checklisteditor2, echo = FALSE}
 show_checklist(c("editor-checklist.csv", "editor-checklist-peer-reviewed-pkg.csv"))
@@ -57,6 +60,7 @@ show_checklist(c("editor-checklist.csv", "editor-checklist-peer-reviewed-pkg.csv
 # Editor checklist for any other post
 
 Copy this checklist to your GitHub review summary.
+You can hover over the top-right corner of the template to make a copy-paste button appear.
 
 ```{r checklisteditorprp2, echo = FALSE}
 show_checklist("editor-checklist.csv")

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -2,17 +2,31 @@
 
 # Post template in Markdown {#templatemd}
 
-INSTRUCT author to copy this template, or get it from roblog
+[Markdown template](/templates/post-template.md) to be saved as `/content/blog/YYYY-MM-DD-slug/index.md`
 
-```{r posttemplate, results="asis"}
+```{r posttemplatemd, results="asis"}
 show_template("post-template.md", lang = "markdown")
 ```
 
 # Post template in R Markdown {#templatermd}
 
-[R Markdown template](https://github.com/ropensci-org/blog-guidance/blob/master/templates/post-template.Rmd) to be saved as `/content/blog/YYYY-MM-DD-slug/index.md`
+[R Markdown template](/templates/post-template.Rmd) to be saved as `/content/blog/YYYY-MM-DD-slug/index.Rmd`
+
+```{r posttemplatermd, results="asis"}
+show_template("post-template.Rmd", lang = "markdown")
+```
+
+# Author file template {#authortemplate}
+
+[Author file template](/templates/author-file-template.md) to be saved as `/content/authors/yourfirstname-yourlastname/_index.md` as described in [Technical Guidelines](#createauthorfile).
+
+```{r authorfiletemplate, results="asis"}
+show_template("author-file-template.md", lang = "yaml")
+```
 
 # Author checklist for a post about a peer-reviewed package
+
+Copy this checklist into the first comment on your pull request. 
 
 ```{r checklistpkg2, echo = FALSE}
 show_checklist(c("submission-checklist.csv", "submission-checklist-peer-reviewed-pkg.csv"))
@@ -20,25 +34,23 @@ show_checklist(c("submission-checklist.csv", "submission-checklist-peer-reviewed
 
 # Author checklist for any other post
 
+Copy this checklist into the first comment on your pull request. 
+
 ```{r checklistother2, echo = FALSE}
 show_checklist("submission-checklist.csv")
 ```
 
-# Author file template {#authortemplate}
-
-INSTRUCT author to copy this template, or get it from roblog
-
-```{r authorfiletemplate, results="asis"}
-show_template("author-file-template.md", lang = "yaml")
-```
-
 # Editor checklist for a post about a peer-reviewed package
 
+Copy this checklist to your GitHub review summary.
+
 ```{r checklisteditor2, echo = FALSE}
-show_checklist(c("editor-checklist-peer-reviewed-pkg.csv", "editor-checklist.csv"))
+show_checklist(c("editor-checklist.csv", "editor-checklist-peer-reviewed-pkg.csv"))
 ```
 
-# Editor checklist for a post about any other peer-reviewed package
+# Editor checklist for any other post
+
+Copy this checklist to your GitHub review summary.
 
 ```{r checklisteditorprp2, echo = FALSE}
 show_checklist("editor-checklist.csv")

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -2,7 +2,7 @@
 
 # Post template in Markdown {#templatemd}
 
-[Markdown template](/templates/post-template.md) to be saved as `/content/blog/YYYY-MM-DD-slug/index.md`
+Markdown template to be saved as `/content/blog/YYYY-MM-DD-slug/index.md`
 
 You can hover over the top-right corner of the template to make a copy-paste button appear.
 
@@ -12,7 +12,7 @@ show_template("post-template.md", lang = "markdown")
 
 # Post template in R Markdown {#templatermd}
 
-[R Markdown template](/templates/post-template.Rmd) to be saved as `/content/blog/YYYY-MM-DD-slug/index.Rmd`
+R Markdown template to be saved as `/content/blog/YYYY-MM-DD-slug/index.Rmd`
 
 You can hover over the top-right corner of the template to make a copy-paste button appear.
 
@@ -22,7 +22,7 @@ show_template("post-template.Rmd", lang = "markdown")
 
 # Author file template {#authortemplate}
 
-[Author file template](/templates/author-file-template.md) to be saved as `/content/authors/yourfirstname-yourlastname/_index.md` as described in [Technical Guidelines](#createauthorfile).
+Author file template to be saved as `/content/authors/yourfirstname-yourlastname/_index.md` as described in [Technical Guidelines](#createauthorfile).
 
 You can hover over the top-right corner of the template to make a copy-paste button appear.
 

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -4,6 +4,8 @@
 
 [Markdown template](/templates/post-template.md) to be saved as `/content/blog/YYYY-MM-DD-slug/index.md`
 
+You can hover over the top-right corner of the template to make a copy-paste button appear.
+
 ```{r posttemplatemd, results="asis"}
 show_template("post-template.md", lang = "markdown")
 ```
@@ -12,6 +14,8 @@ show_template("post-template.md", lang = "markdown")
 
 [R Markdown template](/templates/post-template.Rmd) to be saved as `/content/blog/YYYY-MM-DD-slug/index.Rmd`
 
+You can hover over the top-right corner of the template to make a copy-paste button appear.
+
 ```{r posttemplatermd, results="asis"}
 show_template("post-template.Rmd", lang = "markdown")
 ```
@@ -19,6 +23,8 @@ show_template("post-template.Rmd", lang = "markdown")
 # Author file template {#authortemplate}
 
 [Author file template](/templates/author-file-template.md) to be saved as `/content/authors/yourfirstname-yourlastname/_index.md` as described in [Technical Guidelines](#createauthorfile).
+
+You can hover over the top-right corner of the template to make a copy-paste button appear.
 
 ```{r authorfiletemplate, results="asis"}
 show_template("author-file-template.md", lang = "yaml")

--- a/checklists/editor-checklist-peer-reviewed-pkg.csv
+++ b/checklists/editor-checklist-peer-reviewed-pkg.csv
@@ -1,4 +1,4 @@
+YAML package-version tag
+tags "Software Peer Review", packagename, R, "community" for post authored by non-staff non-editor
 acknowledges and links to reviewers
 links to peer review thread
-package-version YAML tag
-tags "Software Peer Review", packagename, R, "community" for post authored by non-staff non-editor

--- a/checklists/editor-checklist.csv
+++ b/checklists/editor-checklist.csv
@@ -1,10 +1,10 @@
 post follows content guidelines
-YAML description is appropriate for discuss forum 
+post follows Style Guide
 YAML is ok e.g. publication date
-tags are ok
+YAML tags are ok
+YAML description appropriate for discussion forum
 I ran `roblog::ro_lint_md()` on index.md
 I ran `roblog::ro_check_urls()`
-follows Style Guide
 html not included in pull request of Rmd post
 author metadata is provided with correct folder name
 Twitter metadata looks fine (paste post preview link in [Twitter card validator](https://cards-dev.twitter.com/validator))

--- a/checklists/submission-checklist-peer-reviewed-pkg.csv
+++ b/checklists/submission-checklist-peer-reviewed-pkg.csv
@@ -2,4 +2,3 @@ I have added the tags "Software Peer Review", my-packagename, "R".
 I have added the package-version YAML tag.
 I have added acknowledgement of the reviewers' work.
 I have added a link to the software peer review thread.
-

--- a/checklists/submission-checklist-peer-reviewed-pkg.csv
+++ b/checklists/submission-checklist-peer-reviewed-pkg.csv
@@ -1,4 +1,5 @@
-I have added the tag "Software Peer Review".
+I have added the tags "Software Peer Review", my-packagename, "R".
 I have added the package-version YAML tag.
-I have added acknowledgements of the reviewers' work.
-I have included a call to action (how to make contributions, give feedback).
+I have added acknowledgement of the reviewers' work.
+I have added a link to the software peer review thread.
+

--- a/checklists/submission-checklist.csv
+++ b/checklists/submission-checklist.csv
@@ -1,9 +1,8 @@
 I have read the content guidelines.
 I have read the technical guidelines.
-Stef told me whether this should be a blog post or a tech note.
-I included my author metadata.
-I have added relevant tags after browsing existing tags.
 I used the R Markdown template or Markdown template.
-I added my post in a bundle.
-I ran `roblog::ro_lint_md()` on index.md.
-I ran `roblog::ro_check_urls()`
+I have followed the Style Guide.
+I created or updated my author metadata with correct folder name.
+I have added relevant tags after browsing existing tags.
+I ran `roblog::ro_lint_md()` on index.md (optional).
+I ran `roblog::ro_check_urls()` (optional).


### PR DESCRIPTION
- minor checklist edits
- switch appearance order of SwPR and other, for SwPR appendix item
- edit appendix to instruct users on what to do with templates and checklists
- change to relative path for template links
- moved author file in appendix to group templates before checklists