### PR TITLE
New headings, re-arrangements, checkist synchronization

### DIFF
--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -1,6 +1,6 @@
 # (APPENDIX) Appendix {-}
 
-# Post template in Markdown {#templatemd}
+# Template - Post (md) {#templatemd}
 
 Use of this template is described in [Start the post from a template](#templates) and [Walkthrough with code snippets](#usetemplates).
 
@@ -12,7 +12,7 @@ You can hover over the top-right corner of the template to make a copy-paste but
 show_template("https://github.com/ropensci/roweb3/raw/master/archetypes/md/index.md", lang = "markdown")
 ```
 
-# Post template in R Markdown {#templatermd}
+# Template - Post (Rmd) {#templatermd}
 
 Use of this template is described in [Start the post from a template](#templates) and [Walkthrough with code snippets](#usetemplates).
 
@@ -20,7 +20,7 @@ R Markdown template to be saved as `/content/blog/YYYY-MM-DD-slug/index.Rmd`
 
 [Available on GitHub](https://github.com/ropensci/roweb3/blob/master/archetypes/Rmd/index.md) (_not displayed for copy-paste because of "html_preserve" tags_)
 
-# Author file template {#authortemplate}
+# Template - Author file {#authortemplate}
 
 Use of this template is described in [Create or update your author file](#createauthorfile).
 
@@ -32,7 +32,7 @@ You can hover over the top-right corner of the template to make a copy-paste but
 show_template("author-file-template.md", lang = "yaml")
 ```
 
-# Author checklist for a post about a peer-reviewed package {#authorchecklistpeer}
+# Author Checklist - Posts on peer-reviewed packages {#authorchecklistpeer}
 
 Use of this template is described in [Pre-submission checks](#presubchecks).
 
@@ -43,7 +43,7 @@ You can hover over the top-right corner of the template to make a copy-paste but
 show_checklist(c("submission-checklist.csv", "submission-checklist-peer-reviewed-pkg.csv"))
 ```
 
-# Author checklist for any other post {#authorchecklistany}
+# Author Checklist - Other posts {#authorchecklistany}
 
 Use of this template is described in [Pre-submission checks](#presubchecks).
 
@@ -54,7 +54,7 @@ You can hover over the top-right corner of the template to make a copy-paste but
 show_checklist("submission-checklist.csv")
 ```
 
-# Editor checklist for a post about a peer-reviewed package {#editorchecklistpeer}
+# Editor Checklist - Posts on peer-reviewed packages {#editorchecklistpeer}
 
 Use of this template is described in [Review a Post](#review).
 
@@ -65,7 +65,7 @@ You can hover over the top-right corner of the template to make a copy-paste but
 show_checklist(c("editor-checklist.csv", "editor-checklist-peer-reviewed-pkg.csv"))
 ```
 
-# Editor checklist for any other post {#editorchecklistany}
+# Editor checklist - Other posts {#editorchecklistany}
 
 Use of this template is described in [Review a Post](#review).
 
@@ -76,7 +76,7 @@ You can hover over the top-right corner of the template to make a copy-paste but
 show_checklist("editor-checklist.csv")
 ```
 
-# Understanding Twitter cards {#twittercards}
+# Twitter cards {#twittercards}
 
 A [Twitter card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/abouts-cards) means than when a URL is included in a tweet, what other Twitter users see is not the URL but instead a "card", i.e. the metadata from the URL rendered in a nice preview.
 The Twitter metadata in a [post's YAML](whatgoesinyaml) helps it "look good" when an account like R Weekly Live or other readers link to the post in a tweet. 

--- a/authorcontent.Rmd
+++ b/authorcontent.Rmd
@@ -19,7 +19,7 @@ Tech notes can be published on any weekday.
 Both are given the same [promotional treatment](#promote) by rOpenSci.
 
 
-## Themes of posts {#postthemes}
+## Themes {#postthemes}
 
 Read a few [posts](https://ropensci.org/archive/) and consider what you like (or not) about them.
 Most posts written by community members are about packages that have passed rOpenSci software peer review, however, we have posts on a range of topics and we encourage you to consider these or to propose others.
@@ -54,7 +54,7 @@ cat(paste0(
 
 ```
 
-## What goes in your post? {#whatgoesin}
+## Post content {#postcontent}
 
 Since most posts contributed by community members are about packages that have passed software peer review, we use this type of post as an example to outline components you should consider including in your post.
 Some components would not be included if the post is not about a peer reviewed package.

--- a/authorreview.Rmd
+++ b/authorreview.Rmd
@@ -1,4 +1,4 @@
-# Responding to Editor's Review {#respond}
+# Respond to Feedback {#respond}
 
 ```{block, type='summaryblock', echo=TRUE}
 This chapter outlines how an author of a blog post or tech note can find and respond to comments from an editor in the GitHub pull request review interface.

--- a/authortechnical.Rmd
+++ b/authortechnical.Rmd
@@ -19,17 +19,17 @@ Briefly, the process is:
 
 This chapter links to templates for posts and checklists that you can also find in the Appendix.
 
-## Fork the repo and create your post folder {#forkcreate}
+## Fork the `roweb3` repository {#forkcreate}
 
 Fork the rOpenSci website [repository](https://github.com/ropensci/roweb3) and create a new branch to work on your post. 
 For help with this aspect of git/GitHub, we recommend [happygitwithr](https://happygitwithr.com/fork-and-clone.html) and the [pull request helpers of the usethis package](https://usethis.r-lib.org/articles/articles/pr-functions.html).
 
-## Start the post from a template {#templates}
+## Post template {#templates}
 
-If you use RStudio, refer to [the instructions to create your draft with blogdown's New Post Addin](#blogdownaddin).
+Start your post from a template. If you use RStudio, refer to [the instructions to create your draft with blogdown's New Post Addin](#blogdownaddin).
 If not, refer to [the instructions to create your draft manually](#manually).
 
-### Get R Markdown or Markdown template with blogdown’s New Post Addin {#blogdownaddin}
+### New Post Addin {#blogdownaddin}
 
 The blogdown New Post RStudio addin creates the post draft in the correct location and fills the post YAML based on metadata you'll have entered.[^2]
 
@@ -54,7 +54,7 @@ knitr::include_graphics("images/blogdownaddin.png", dpi = 25)
   * Select any relevant tag and/or create new ones.
   * Click on "Done", your post draft will have been created and opened.
 
-### Get R Markdown or Markdown template manually {#manually}
+### Manually {#manually}
 
 Create a folder `YYYY-MM-DD-slug/` (e.g. `2020-01-20-rorcid/`) under `/content/blog/` or `content/technotes/` for a blog post and a tech note, respectively.
 Your post source and its images should live in `/content/blog/YYYY-MM-DD-slug/` or `/content/technotes/YYYY-MM-DD-slug/`.[^1]
@@ -63,11 +63,11 @@ Your post source and its images should live in `/content/blog/YYYY-MM-DD-slug/` 
 
 * [Markdown template](#templatemd) is to be saved as `/content/blog/YYYY-MM-DD-slug/index.md`.
 
-## Walkthrough with code snippets {#usetemplates}
+## Adding content {#usetemplates}
 
-### What goes in YAML {#whatgoesinyaml}
+### YAML {#whatgoesinyaml}
 
-This is the YAML from our [post template](#templatermd), with comments to explain some components:
+The YAML sets the metadata for a post. This is the YAML from our [post template](#templatermd), with comments to explain some components:
 
 ```{r posttemplate, results="asis"}
 show_template("https://github.com/ropensci/roweb3/raw/master/archetypes/md/index.md", 
@@ -75,13 +75,13 @@ show_template("https://github.com/ropensci/roweb3/raw/master/archetypes/md/index
               yaml_only = TRUE)
 ```
 
-#### Add subject tags
+#### Subject tags
 
 Add tags to the YAML of your post to make it more findable. Browse [our page that lists all tags in use](https://ropensci.org/tags/) and re-use an existing tag rather than creating a new one e.g. 'packages' exists, so use that, rather than 'package'.
 
 For a post about your peer-reviewed package, use 'Software Peer Review', 'R', 'community', 'packages', the package name, tags that were [topic labels](https://github.com/ropensci/software-review/labels) in your package review such as 'data-access', and any others you see fit.
 
-#### Optional Twitter cards metadata
+#### Twitter cards metadata (optional)
 
 If you're curious about the `description`, `twitterImg` YAML fields in the post metadata and how they can help draw readers to your post, refer to [our explanation of Twitter cards](#twittercards).
 
@@ -97,7 +97,7 @@ Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/
 - A tech note.
 Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/technotes/2018-10-06-av-release.md) with the [live tech note](https://ropensci.org/technotes/2018/10/06/av-release/).
 
-### To add an image {#addimage}
+### External images {#addimage}
 
 If your blog post has any images that are **not** generated from R Markdown, put them in the same folder as your post source (`/content/blog/YYYY-MM-DD-slug/` or `/content/technotes/YYYY-MM-DD-slug/`).
 All non-R Markdown images should be in this folder (do not link to external services like imgur).
@@ -159,7 +159,7 @@ knitr::include_graphics("images/imgtxt.png")
 <code>&lt;!\-\-/html_preserve\-\-></code>  
 
 
-### To add a figure generated with R {#addfigure}
+### Rmd-created images {#addfigure}
 
 When using [our R Markdown template](https://github.com/ropensci/roweb3/blob/master/archetypes/Rmd/index.md) the knitr hook in the setup chunk actually creates the necessary Hugo shortcodes. 
 Therefore you don't need to worry about paths.
@@ -175,7 +175,7 @@ plot(1:10)
 
 This chunk above produces a figure with _"alternative text please make it informative"_ as alternative text, _"title of the image"_ as title, _"this is what this image shows, write it here or in the paragraph after the image as you prefer"_ as caption, and a width of 300 pixels.
 
-### To add a citation {#addcitation}
+### Citations {#addcitation}
 
 To add citations, refer to them in the body of your post:
 ```
@@ -192,7 +192,7 @@ And list your sources at the bottom of your post:
 [^3]: Hugo static site generator. https://gohugo.io/
 ```
 
-#### How to find citation text for a package or article
+#### Finding citations
 
 To get the citation for an R package, run `citation("packagename")`.
 
@@ -211,7 +211,7 @@ To get the citation for an article in [Google Scholar](https://scholar.google.co
 knitr::include_graphics("images/citation-gscholar.png")
 ```
 
-### To embed a tweet {#addtweet}
+### Embedded tweets {#addtweet}
 
 Use a [Hugo shortcode](https://gohugo.io/content-management/shortcodes/#tweet) to embed a tweet using its ID e.g. `{{< tweet 1138216112808529920 >}}`. In R Markdown, shortcodes need to be html escaped, refer to [the template](https://github.com/ropensci/roweb3/blob/master/archetypes/Rmd/index.md) for an example.
 
@@ -230,7 +230,9 @@ Use a [Hugo shortcode](https://gohugo.io/content-management/shortcodes/#tweet) t
 - Use informative [alternative text](#addimage) for all images.
 - Add new line at end of each sentence ([makes diffs easier to interpret and easier for editor to suggest specific changes](https://cirosantilli.com/markdown-style-guide#line-wrapping)).
 
-## Create or update your author file {#createauthorfile}
+## Author files {#createauthorfile}
+
+Create or update your author file.
 
 ### Why?
 The rOpenSci website has a page listing [all authors](https://ropensci.org/author/) who have contributed to a blog post, tech note, or presented in a Community Call.
@@ -305,22 +307,22 @@ You can use functions in the [roblog package to do some automated checks](https:
 
 In the first comment of your pull request submitting a post, please copy-paste the checklist corresponding to your post (hover, a copy-paste button will appear at the top-right corner of the shaded area) and check off items.
 
-### Checklist for a post about a peer-reviewed package
+### Author Checklist - Posts on peer-reviewed packages
 
 ```{r checklistpkg, echo = FALSE}
 show_checklist(c("submission-checklist.csv", "submission-checklist-peer-reviewed-pkg.csv"))
 ```
 
-### Checklist for any other post
+### Author Checklist - Other posts
 
 ```{r checklistother, echo = FALSE}
 show_checklist("submission-checklist.csv")
 ```
 
-## Submit your draft post {#submitpost}
+## Submit draft post {#submitpost}
 Once you've drafted your blog post, you can [preview locally using Hugo](#localpreview) (recommended) or skip to the next step to make a pull request and preview that.
 
-### Local preview with Hugo {#localpreview}
+### Local preview {#localpreview}
 
 If you wish to preview your post locally, as it will appear in our site, you must install Hugo.
 To install, refer to [Hugo docs](https://gohugo.io/getting-started/installing/) or run `blogdown::install_hugo()`.
@@ -331,7 +333,7 @@ The version of Hugo used by the rOpenSci web server is defined in [netlify.toml]
 
 When this preview looks good to you, you should submit your post as a pull request.
 
-### Make a pull request
+### Create pull request
 
 If using the R Markdown template, knitting `index.Rmd` (RStudio knit button, or `rmarkdown::render(<path_to_file>)`) will generate both `index.md` and `index.html`.
 `index.html` will be ignored; do commit both `index.Rmd` and `index.md`.

--- a/authortechnical.Rmd
+++ b/authortechnical.Rmd
@@ -107,6 +107,7 @@ The blogdown New Post RStudio addin creates the post draft in the correct locati
 * Re-start R
 * In RStudio, open the forked `roweb3` project
 * Create a new post by running Addins > New Post or `blogdown:::new_post_addin()`
+* Leave "Categories" blank
 
 ```{r blogdownaddin, echo = FALSE, fig.cap = "blogdown's New Post Addin.", out.width = "70%", fig.align="center"}
 knitr::include_graphics("images/blogdownaddin.png", dpi = 25)
@@ -148,7 +149,7 @@ show_template("https://github.com/ropensci/roweb3/raw/master/archetypes/md/index
 
 Add tags to the YAML of your post to make it more findable. Browse [our page that lists all tags in use](https://ropensci.org/tags/) and re-use an existing tag rather than creating a new one e.g. 'packages' exists, so use that, rather than 'package'.
 
-For a post about your peer-reviewed package, use 'Software Peer Review', 'R', 'community', 'packages', the package name, tags that were [topic labels](https://github.com/ropensci/software-review/labels) in your package review such as 'data-access', and any others you see fit.
+For a post about your peer-reviewed package, use 'Software Peer Review', 'community', 'packages', the package name, tags that were [topic labels](https://github.com/ropensci/software-review/labels) in your package review such as 'data-access', and any others you see fit.
 
 #### Twitter cards metadata (optional)
 
@@ -353,7 +354,7 @@ When this preview looks good to you, you should submit your post as a pull reque
 
 * Open a [**draft** pull request (PR)](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) from your fork ([using the web interface](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork), see step 8 for creating a **draft**), or [`usethis::pr_push()`](https://usethis.r-lib.org/articles/articles/pr-functions.html#submit-pull-request) that will save you some work and that will in the end open the same web interface where you can choose Draft PR in the last step)
 
-* If you opened a PR instead of a **draft** PR, the PR can't go back to a draft stage but no problem, only make sure to add a comment to the PR mentioning `@ropensci/blog-editors` once to tell them the PR isn't ready for review 
+* If you opened a PR instead of a **draft** PR, you can [convert it to a draft](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft) by clicking on "Still in progress? Convert to draft" on the right panel under "Reviewers".
 
 ### Add checklist
 
@@ -375,9 +376,6 @@ knitr::include_graphics("images/hugocheckspassed.png")
 ### Submit post
 
 * Mark the draft PR as ready for review at least one week prior to the planned publication date. A review from blog editor(s) will be automatically requested by GitHub.
-
-* If you opened a PR instead of a **draft** PR, add a comment to the PR mentioning `@ropensci/blog-editors` to tell them the PR is ready for review.
-
 
 
 [^1]: In Hugo speak, we'd say your post is a [leaf bundle](https://gohugo.io/content-management/page-bundles/#leaf-bundles).

--- a/authortechnical.Rmd
+++ b/authortechnical.Rmd
@@ -24,6 +24,75 @@ This chapter links to templates for posts and checklists that you can also find 
 Fork the rOpenSci website [repository](https://github.com/ropensci/roweb3) and create a new branch to work on your post. 
 For help with this aspect of git/GitHub, we recommend [happygitwithr](https://happygitwithr.com/fork-and-clone.html) and the [pull request helpers of the usethis package](https://usethis.r-lib.org/articles/articles/pr-functions.html).
 
+## Author files {#createauthorfile}
+
+Create or update your author file.
+
+### Why?
+The rOpenSci website has a page listing [all authors](https://ropensci.org/author/) who have contributed to a blog post, tech note, or presented in a Community Call.
+A click on your by-line in a post takes the reader to your author page that has links to your online home, possibly your Twitter or GitHub profile(s), and a list of all the content you’ve authored on our site.
+For staff and leadership team members, editors for software peer review, or members of our Code of Conduct Committee, their rOpenSci title is also listed on their author page.
+
+
+### How?
+If you don't already have an author page, create a folder called `yourfirstname-yourlastname` in your local copy of [`roweb3/content/author/`](https://github.com/ropensci/roweb3/tree/master/content/author).
+You can have accents, middle initials, or hyphens appear in your name if you name your folder appropriately. That can be tricky so we have examples below.
+
+In that folder, create a file called `_index.md` with information about your online presence.
+You can copy this template below (or get it via [roblog](https://docs.ropensci.org/roblog/reference/blog-posts.html) after installing it via `install.packages("roblog", repos = "https://dev.ropensci.org")` ).
+
+```{r authorfiletemplate1, results="asis"}
+show_template("author-file-template.md", 
+              lang = "yaml",
+              details = TRUE
+)
+```
+
+At minimum, provide your name and a link or your Twitter, GitHub, or GitLab username.
+Add your usernames or ID's without the "@" or the "https:...". The link field can be your personal website URL, for example.
+
+### Examples 
+
+This author file, [`/author/kelly-obriant/_index.md`](https://github.com/ropensci/roweb3/blob/master/content/author/kelly-obriant/_index.md) 
+
+```yaml
+---
+name: Kelly O'Briant
+link: https://kellobri.github.io/
+twitter: kellrstats
+github: kellobri
+---
+```
+
+... generates [Kelly O'Briant's author page](https://ropensci.org/author/kelly-obriant/)
+
+```{r authorpage, fig.cap ="Screenshot of Kelly O'Briant's author page"}
+knitr::include_graphics("images/authorpage-1.png")
+```
+
+
+This author file, [`/author/maëlle-salmon/_index.md`](https://github.com/ropensci/roweb3/blob/master/content/author/ma%C3%ABlle-salmon/_index.md)
+
+```yaml
+---
+name: Maëlle Salmon
+twitter: ma_salmon
+bio: rOpenSci Research Software Engineer, Associate editor of rOpenSci Software Peer Review
+github: maelle
+gitlab: maelle
+keybase: maelle_salmon
+orcid: 0000-0002-2815-0399
+---
+```
+
+... generates [Maëlle Salmon's author page](https://ropensci.org/author/ma%C3%ABlle-salmon/).
+
+For an example of how to name the folder with an accent and initials, see this [author file](https://github.com/ropensci/roweb3/blob/master/content/author/rich%C3%A8l-j.c.-bilderbeek/_index.md) that generates [Richèl J.C. Bilderbeek's author page](https://ropensci.org/author/rich%C3%A8l-j.c.-bilderbeek/).
+The folder name must include accents, initials with periods, and hyphens for spaces, in order to link to their blog content.
+
+Look at [other people's folder names](https://github.com/ropensci/roweb3/tree/master/content/author) for examples. 
+
+
 ## Post template {#templates}
 
 Start your post from a template. If you use RStudio, refer to [the instructions to create your draft with blogdown's New Post Addin](#blogdownaddin).
@@ -86,16 +155,6 @@ For a post about your peer-reviewed package, use 'Software Peer Review', 'R', 'c
 If you're curious about the `description`, `twitterImg` YAML fields in the post metadata and how they can help draw readers to your post, refer to [our explanation of Twitter cards](#twittercards).
 
 Delete `description` and `twitterImg` YAML fields if you don't use them. 
-
-### Examples
-
-Comparing the raw Markdown to the live posts in these examples might be helpful.
-
-- A blog post about a package that has passed software peer review.
-Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/blog/2019-10-21-rmangal.md) with the [live post](https://ropensci.org/blog/2019/10/21/rmangal/).
-
-- A tech note.
-Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/technotes/2018-10-06-av-release.md) with the [live tech note](https://ropensci.org/technotes/2018/10/06/av-release/).
 
 ### External images {#addimage}
 
@@ -215,6 +274,16 @@ knitr::include_graphics("images/citation-gscholar.png")
 
 Use a [Hugo shortcode](https://gohugo.io/content-management/shortcodes/#tweet) to embed a tweet using its ID e.g. `{{< tweet 1138216112808529920 >}}`. In R Markdown, shortcodes need to be html escaped, refer to [the template](https://github.com/ropensci/roweb3/blob/master/archetypes/Rmd/index.md) for an example.
 
+### Examples
+
+Comparing the raw Markdown to the live posts in these examples might be helpful.
+
+- A blog post about a package that has passed software peer review.
+Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/blog/2019-10-21-rmangal.md) with the [live post](https://ropensci.org/blog/2019/10/21/rmangal/).
+
+- A tech note.
+Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/technotes/2018-10-06-av-release.md) with the [live tech note](https://ropensci.org/technotes/2018/10/06/av-release/).
+
 ## Style Guide {#styleguide}
 
 - For formatting of package names, functions, and code, follow the [tidyverse style guidance](https://style.tidyverse.org/documentation.html#r-code). Format package names as regular text (no quotes).
@@ -230,102 +299,44 @@ Use a [Hugo shortcode](https://gohugo.io/content-management/shortcodes/#tweet) t
 - Use informative [alternative text](#addimage) for all images.
 - Add new line at end of each sentence ([makes diffs easier to interpret and easier for editor to suggest specific changes](https://cirosantilli.com/markdown-style-guide#line-wrapping)).
 
-## Author files {#createauthorfile}
-
-Create or update your author file.
-
-### Why?
-The rOpenSci website has a page listing [all authors](https://ropensci.org/author/) who have contributed to a blog post, tech note, or presented in a Community Call.
-A click on your by-line in a post takes the reader to your author page that has links to your online home, possibly your Twitter or GitHub profile(s), and a list of all the content you’ve authored on our site.
-For staff and leadership team members, editors for software peer review, or members of our Code of Conduct Committee, their rOpenSci title is also listed on their author page.
-
-
-### How?
-If you don't already have an author page, create a folder called `yourfirstname-yourlastname` in your local copy of [`roweb3/content/author/`](https://github.com/ropensci/roweb3/tree/master/content/author).
-You can have accents, middle initials, or hyphens appear in your name if you name your folder appropriately. That can be tricky so we have examples below.
-
-In that folder, create a file called `_index.md` with information about your online presence.
-You can copy this template below (or get it via [roblog](https://docs.ropensci.org/roblog/reference/blog-posts.html) after installing it via `install.packages("roblog", repos = "https://dev.ropensci.org")` ).
-
-```{r authorfiletemplate1, results="asis"}
-show_template("author-file-template.md", 
-              lang = "yaml",
-              details = TRUE
-)
-```
-
-At minimum, provide your name and a link or your Twitter, GitHub, or GitLab username.
-Add your usernames or ID's without the "@" or the "https:...". The link field can be your personal website URL, for example.
-
-### Examples 
-
-This author file, [`/author/kelly-obriant/_index.md`](https://github.com/ropensci/roweb3/blob/master/content/author/kelly-obriant/_index.md) 
-
-```yaml
----
-name: Kelly O'Briant
-link: https://kellobri.github.io/
-twitter: kellrstats
-github: kellobri
----
-```
-
-... generates [Kelly O'Briant's author page](https://ropensci.org/author/kelly-obriant/)
-
-```{r authorpage, fig.cap ="Screenshot of Kelly O'Briant's author page"}
-knitr::include_graphics("images/authorpage-1.png")
-```
-
-
-This author file, [`/author/maëlle-salmon/_index.md`](https://github.com/ropensci/roweb3/blob/master/content/author/ma%C3%ABlle-salmon/_index.md)
-
-```yaml
----
-name: Maëlle Salmon
-twitter: ma_salmon
-bio: rOpenSci Research Software Engineer, Associate editor of rOpenSci Software Peer Review
-github: maelle
-gitlab: maelle
-keybase: maelle_salmon
-orcid: 0000-0002-2815-0399
----
-```
-
-... generates [Maëlle Salmon's author page](https://ropensci.org/author/ma%C3%ABlle-salmon/).
-
-For an example of how to name the folder with an accent and initials, see this [author file](https://github.com/ropensci/roweb3/blob/master/content/author/rich%C3%A8l-j.c.-bilderbeek/_index.md) that generates [Richèl J.C. Bilderbeek's author page](https://ropensci.org/author/rich%C3%A8l-j.c.-bilderbeek/).
-The folder name must include accents, initials with periods, and hyphens for spaces, in order to link to their blog content.
-
-Look at [other people's folder names](https://github.com/ropensci/roweb3/tree/master/content/author) for examples. 
-
 ## Pre-submission checks {#presubchecks}
+
+### Knit post
+
+If using the R Markdown template, knitting `index.Rmd` (RStudio knit button, or `rmarkdown::render(<path_to_file>)`) will generate both `index.md` and `index.html` (
+`index.html` will be ignored, but we need an `index.md`). Commit both `index.Rmd` and `index.md`. 
+
+### Check with `roblog`
 
 You can use functions in the [roblog package to do some automated checks](https://docs.ropensci.org/roblog/articles/checks-guidance.html) on your post. 
 
 - `ro_lint_md()` to check and enforce use of complete alternative descriptions for image, of relative links to rOpenSci website, of [Hugo shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugos-built-in-shortcodes) for tweets, of lower camelCase for rOpenSci name
 - `ro_check_urls()` to check for URLs that might be broken 
 
-In the first comment of your pull request submitting a post, please copy-paste the checklist corresponding to your post (hover, a copy-paste button will appear at the top-right corner of the shaded area) and check off items.
+### Author Checklist {#checklists}
 
-### Author Checklist - Posts on peer-reviewed packages
+Pick the appropriate checklist for your post and ensure you checked everything off. 
+Hover the mouse over the list and a copy-paste button will appear at the 
+top-right corner of the shaded area.
+
+#### Posts on peer-reviewed packages
 
 ```{r checklistpkg, echo = FALSE}
 show_checklist(c("submission-checklist.csv", "submission-checklist-peer-reviewed-pkg.csv"))
 ```
 
-### Author Checklist - Other posts
+#### Other posts
 
 ```{r checklistother, echo = FALSE}
 show_checklist("submission-checklist.csv")
 ```
 
-## Submit draft post {#submitpost}
-Once you've drafted your blog post, you can [preview locally using Hugo](#localpreview) (recommended) or skip to the next step to make a pull request and preview that.
-
 ### Local preview {#localpreview}
 
 If you wish to preview your post locally, as it will appear in our site, you must install Hugo.
-To install, refer to [Hugo docs](https://gohugo.io/getting-started/installing/) or run `blogdown::install_hugo()`.
+To install, refer to [Hugo docs](https://gohugo.io/getting-started/installing/) or run `blogdown::install_hugo()`. 
+
+**Note:** You can also preview your blog post online through the pull request before the final submission
 
 Then run `hugo serve` in the repo directory to start a local server on http://localhost:1313. 
 
@@ -333,16 +344,22 @@ The version of Hugo used by the rOpenSci web server is defined in [netlify.toml]
 
 When this preview looks good to you, you should submit your post as a pull request.
 
-### Create pull request
 
-If using the R Markdown template, knitting `index.Rmd` (RStudio knit button, or `rmarkdown::render(<path_to_file>)`) will generate both `index.md` and `index.html`.
-`index.html` will be ignored; do commit both `index.Rmd` and `index.md`.
+
+## Submit draft post {#submitpost}
+
+
+### Create draft pull request
 
 * Open a [**draft** pull request (PR)](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) from your fork ([using the web interface](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork), see step 8 for creating a **draft**), or [`usethis::pr_push()`](https://usethis.r-lib.org/articles/articles/pr-functions.html#submit-pull-request) that will save you some work and that will in the end open the same web interface where you can choose Draft PR in the last step)
 
-* Mark the draft PR as ready for review at least one week prior to the planned publication date. A review from blog editor(s) will be automatically requested by GitHub.
+* If you opened a PR instead of a **draft** PR, the PR can't go back to a draft stage but no problem, only make sure to add a comment to the PR mentioning `@ropensci/blog-editors` once to tell them the PR isn't ready for review 
 
-* If you opened a PR instead of a **draft** PR, the PR can't go back to a draft stage but no problem, only make sure to add a comment to the PR mentioning `@ropensci/blog-editors` once to tell them the PR isn't ready for review, and another comment later (again mentioning `@ropensci/blog-editors`) to tell them the PR is really ready for review.
+### Add checklist
+
+In the first comment of your pull request submitting a post, please copy-paste the [checklist](#checklists) corresponding to your post and check off the items.
+
+### Preview online
 
 From the PR, Netlify will start building the new version of the site within seconds and you can preview your changes to make sure everything looks as intended.
 Otherwise push additional fixes till things look right.
@@ -354,6 +371,14 @@ knitr::include_graphics("images/hugochecks.png")
 ```{r hugocheckspassed, echo = FALSE, fig.cap = "All checks have passed."}
 knitr::include_graphics("images/hugocheckspassed.png")
 ```
+
+### Submit post
+
+* Mark the draft PR as ready for review at least one week prior to the planned publication date. A review from blog editor(s) will be automatically requested by GitHub.
+
+* If you opened a PR instead of a **draft** PR, add a comment to the PR mentioning `@ropensci/blog-editors` to tell them the PR is ready for review.
+
+
 
 [^1]: In Hugo speak, we'd say your post is a [leaf bundle](https://gohugo.io/content-management/page-bundles/#leaf-bundles).
 [^2]: If you don't use RStudio you can still use the addin, but the new post will be opened in the editor returned by [`getOption("editor")`](https://stat.ethz.ch/R-manual/R-devel/library/base/html/options.html), that you might need to configure.

--- a/checklists/editor-checklist-peer-reviewed-pkg.csv
+++ b/checklists/editor-checklist-peer-reviewed-pkg.csv
@@ -1,4 +1,4 @@
 YAML package-version included
-YAML subject tags - software peer review, packagename, R; add "community" for post by non-staff non-editor
+YAML subject tags - software peer review, packagename, R
 acknowledges and links to reviewers
 links to peer review thread

--- a/checklists/editor-checklist-peer-reviewed-pkg.csv
+++ b/checklists/editor-checklist-peer-reviewed-pkg.csv
@@ -1,4 +1,4 @@
 YAML package-version included
-YAML subject tags - software peer review, packagename, R
+YAML subject tags - software peer review, packagename
 acknowledges and links to reviewers
 links to peer review thread

--- a/checklists/editor-checklist.csv
+++ b/checklists/editor-checklist.csv
@@ -9,4 +9,4 @@ html not included in pull request of Rmd post
 I ran `roblog::ro_lint_md()` on index.md
 I ran `roblog::ro_check_urls()` on index.md
 I ran a spell-check on index.md
-YAML subject tags are ok
+YAML subject tags are ok (add "community" for post by non-staff non-editor)

--- a/checklists/submission-checklist-peer-reviewed-pkg.csv
+++ b/checklists/submission-checklist-peer-reviewed-pkg.csv
@@ -1,4 +1,4 @@
-I have added the tags - Software Peer Review, my-packagename, R.
+I have added the tags - Software Peer Review, my-packagename.
 I have added the package-version YAML tag.
 I have added acknowledgement of the reviewers' work (with links to reviewers).
 I have added a link to the software peer review thread.

--- a/checklists/submission-checklist-peer-reviewed-pkg.csv
+++ b/checklists/submission-checklist-peer-reviewed-pkg.csv
@@ -1,5 +1,5 @@
 I have added the tags - Software Peer Review, my-packagename, R.
 I have added the package-version YAML tag.
-I have added acknowledgement of the reviewers' work.
+I have added acknowledgement of the reviewers' work (with links to reviewers).
 I have added a link to the software peer review thread.
 I ran a spell-check on index.md.

--- a/checklists/submission-checklist.csv
+++ b/checklists/submission-checklist.csv
@@ -3,7 +3,7 @@ I have read the Technical Guidelines.
 I used or followed the R Markdown or Markdown template.
 I have followed the Style Guide.
 I created or updated my author metadata with correct folder name.
-I have added relevant tags after browsing existing tags.
+I have added relevant tags after browsing existing tags (incuding "community" tag).
 I ran `roblog::ro_lint_md()` on index.md (optional).
 I ran `roblog::ro_check_urls()` on index.md (optional).
 I ran a spell-check on index.md.

--- a/editor.Rmd
+++ b/editor.Rmd
@@ -63,13 +63,13 @@ We don't (yet?) have templated editor response text, but here are helpful things
 When your review is complete, click [_Comment_, _Approve_, or _Request changes_](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/reviewing-proposed-changes-in-a-pull-request#submitting-your-review), at your discretion. 
 This will trigger a notificaton to the author.
 
-### Checklist for a post about a peer-reviewed package
+### Editor checklist - Posts on peer-reviewed packages
 
 ```{r checklisteditorprp, echo = FALSE}
 show_checklist(c("editor-checklist.csv", "editor-checklist-peer-reviewed-pkg.csv"))
 ```
 
-### Checklist for any other post
+### Editor checklist - Other posts
 
 ```{r checklisteditor, echo = FALSE}
 show_checklist("editor-checklist.csv")


### PR DESCRIPTION
I have shortened/simplified headings, and rearranged some of the content, specifically the submission sections to clarify the order of operations, and to highlight that users should use a checklist and how to preview. Hopefully this will result in less confusing blog submissions. 
I also tweaked the checklists to ensure the editor and author checklists reflected the same expectations. 