### PR TITLE
Move tech notes to blogs but tag as tech note

### DIFF
--- a/authortechnical.Rmd
+++ b/authortechnical.Rmd
@@ -117,17 +117,18 @@ knitr::include_graphics("images/blogdownaddin.png", dpi = 25)
   * Enter your name if `whoami` wasn't able to guess it.
   * Choose the correct date.
   * Enter a new slug if the default one is too long.
-  * Choose "blog" or "technotes" as a Subdirectory from the drop-down menu.
+  * Choose "blog" as a Subdirectory from the drop-down menu.
   * Choose an Archetype, Rmd or md, from the drop-down menu.
   * Also choose the correct Format: .Rmd if Rmd, Markdown (.md) if md. Never choose .RMarkdown.
   * Ignore Categories.
-  * Select any relevant tag and/or create new ones.
+  * Select "tech notes" tag if this is a tech note
+  * Select any other relevant tags and/or create new ones
   * Click on "Done", your post draft will have been created and opened.
 
 ### Manually {#manually}
 
-Create a folder `YYYY-MM-DD-slug/` (e.g. `2020-01-20-rorcid/`) under `/content/blog/` or `content/technotes/` for a blog post and a tech note, respectively.
-Your post source and its images should live in `/content/blog/YYYY-MM-DD-slug/` or `/content/technotes/YYYY-MM-DD-slug/`.[^1]
+Create a folder `YYYY-MM-DD-slug/` (e.g. `2020-01-20-rorcid/`) under `/content/blog/`
+Your post source and its images should live in `/content/blog/YYYY-MM-DD-slug/`.[^1]
 
 * [R Markdown template](#templatermd) is to be saved as `/content/blog/YYYY-MM-DD-slug/index.Rmd`. It will need to be knit (RStudio knit button, or `rmarkdown::render(<path_to_file>)`). Add both `index.Rmd` and `index.md`to your PR.
 
@@ -159,7 +160,7 @@ Delete `description`, `twitterImg` and `twitterAlt` YAML fields if you don't use
 
 ### External images {#addimage}
 
-If your blog post has any images that are **not** generated from R Markdown, put them in the same folder as your post source (`/content/blog/YYYY-MM-DD-slug/` or `/content/technotes/YYYY-MM-DD-slug/`).
+If your blog post has any images that are **not** generated from R Markdown, put them in the same folder as your post source (`/content/blog/YYYY-MM-DD-slug/`).
 All non-R Markdown images should be in this folder (do not link to external services like imgur).
 To reference them in your post, use `name-of-image.png`. 
 If your image is e.g. an hex logo, it might look better with a transparent background because the blog background is not exactly white.
@@ -283,7 +284,7 @@ Comparing the raw Markdown to the live posts in these examples might be helpful.
 Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/blog/2019-10-21-rmangal.md) with the [live post](https://ropensci.org/blog/2019/10/21/rmangal/).
 
 - A tech note.
-Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/technotes/2018-10-06-av-release.md) with the [live tech note](https://ropensci.org/technotes/2018/10/06/av-release/).
+Compare [raw markdown](https://raw.githubusercontent.com/ropensci/roweb3/master/content/blog/2018-10-06-av-release.md) with the [live tech note](https://ropensci.org/technotes/2018/10/06/av-release/).
 
 ## Style Guide {#styleguide}
 

--- a/checklists/editor-checklist.csv
+++ b/checklists/editor-checklist.csv
@@ -9,4 +9,4 @@ html not included in pull request of Rmd post
 I ran `roblog::ro_lint_md()` on index.md
 I ran `roblog::ro_check_urls()` on index.md
 I ran a spell-check on index.md
-YAML subject tags are ok (add "community" for post by non-staff non-editor)
+YAML subject tags are ok ("tech notes" for tech notes; "community" for non-staff non-editor)

--- a/checklists/submission-checklist.csv
+++ b/checklists/submission-checklist.csv
@@ -4,6 +4,7 @@ I used or followed the R Markdown or Markdown template.
 I have followed the Style Guide.
 I created or updated my author metadata with correct folder name.
 I have added relevant tags after browsing existing tags (incuding "community" tag).
+I have added the "tech notes" tag if this is a technote.
 I ran `roblog::ro_lint_md()` on index.md (optional).
 I ran `roblog::ro_check_urls()` on index.md (optional).
 I ran a spell-check on index.md.

--- a/editor-meta.Rmd
+++ b/editor-meta.Rmd
@@ -14,7 +14,7 @@ The team is maintained by [`@stefaniebutland`](https://github.com/stefaniebutlan
 
 * Blog editors have write access to the roweb3 repo.
 
-* Blog editors are ["code owners"](https://github.com/ropensci/roweb3/blob/master/.github/CODEOWNERS) of `roweb3/content/technotes`, `roweb3/content/blog`, `roweb3/content/commcalls` according to [roweb3's CODEOWNERS file ](https://github.com/ropensci/roweb3/blob/master/.github/CODEOWNERS) so any PR touching a file under these paths will automatically request their review. When one of them posts a review, it will be marked as ["on behalf of `@ropensci/blog-editors`"](https://github.com/ropensci/roweb3/pull/619#issuecomment-589680666).
+* Blog editors are ["code owners"](https://github.com/ropensci/roweb3/blob/master/.github/CODEOWNERS) of `roweb3/content/blog`, `roweb3/content/commcalls` according to [roweb3's CODEOWNERS file ](https://github.com/ropensci/roweb3/blob/master/.github/CODEOWNERS) so any PR touching a file under these paths will automatically request their review. When one of them posts a review, it will be marked as ["on behalf of `@ropensci/blog-editors`"](https://github.com/ropensci/roweb3/pull/619#issuecomment-589680666).
 
 For adding a new blog editor, the team maintainer or any ropensci admin
 


### PR DESCRIPTION
Fixes #172

Changes:
- tech notes are created in /content/blog
- tech notes require the "tech notes" tag
- check lists include checks for the "tech notes" tag
- removed references to /content/technotes for editors