### PR TITLE
add a category

### DIFF
--- a/posts/posts.csv
+++ b/posts/posts.csv
@@ -2,6 +2,7 @@ category; title; url; description
 About a peer-reviewed package developed by the authors; rmangal: Making Ecological Networks Easily Accessible;https://ropensci.org/blog/2019/10/21/rmangal/;talks through the scientific problem and context, shows some code examples, and talks about peer review but doesn't make that the dominant part of the post.
 About a peer-reviewed package developed by the authors;Forcing Yourself to Make Your Life Easier;https://ropensci.org/blog/2018/04/12/ijtiff/;is an honest post with some reflection and an important message.
 About a peer-reviewed package developed by the authors;The av Package: Production Quality Video in R;https://ropensci.org/technotes/2018/10/06/av-release/;(tech note) is to the point. av is not a peer-reviewed package but this is a good example of a tech note. 
+About a group of packages used in a research domain;Using Open-Access Tools (rentrez, taxize) to Find Coronaviruses, Their Genetic Sequences, and Their Hosts;https://ropensci.org/blog/2020/11/10/coronaviruses-and-hosts/;Together, the packages rentrez and taxize can extract standardised data on viruses and their hosts from genetic records.
 Major updates to key packages;(Re)introducing skimr v2 - A year in the life of an open source R project;https://ropensci.org/blog/2019/10/29/skimrv2/);
 Major updates to key packages;drake transformed;https://ropensci.org/technotes/2019/03/18/drake-700/;(technote)
 Major updates to key packages;drake's improved high-performance computing power;https://ropensci.org/technotes/2018/05/18/drake-hpc/;(technote)


### PR DESCRIPTION
From comment on Google Doc. 

The other categories we added to the doc (updates on projects, Describe a package development challenge and call to feedback to improve the dev guide) are categories for staff I think so not worth adding?