### PR TITLE
Update installation instructions

### DIFF
--- a/authortechnical.Rmd
+++ b/authortechnical.Rmd
@@ -102,7 +102,7 @@ If not, refer to [the instructions to create your draft manually](#manually).
 
 The blogdown New Post RStudio addin creates the post draft in the correct location and fills the post YAML based on metadata you'll have entered.[^2]
 
-* Install `whoami` (`install.packages("whoami")`), and `blogdown` above version 1.1.10 (at the moment of writing, only available from GitHub, so `remotes::install_github("rstudio/blogdown")`).
+* Install `whoami` and `blogdown` (`install.packages(c("whoami", "blogdown"))`).
 * Install Hugo (to preview the post): `blogdown::install_hugo()`.
 * Re-start R.
 * In RStudio, open the forked `roweb3` project.

--- a/checklists/submission-checklist-peer-reviewed-pkg.csv
+++ b/checklists/submission-checklist-peer-reviewed-pkg.csv
@@ -2,4 +2,3 @@ I have added the tags - Software Peer Review, my-packagename.
 I have added the package-version YAML tag.
 I have added acknowledgement of the reviewers' work (with links to reviewers).
 I have added a link to the software peer review thread.
-I ran a spell-check on index.md.


### PR DESCRIPTION
Current version on CRAN of `blogdown` is **1.5**.  Version 1.2 (above 1.1.10) was released on 2021-03-04 , see <https://cran.r-project.org/src/contrib/Archive/blogdown/>