### PR TITLE
Doc interviewee field

### DIFF
--- a/inst/checklists/editor-checklist.csv
+++ b/inst/checklists/editor-checklist.csv
@@ -12,6 +12,6 @@ I ran a spell-check on index.md
 YAML subject tags are ok ("tech notes" for tech notes; "community" for non-staff non-editor)
 YAML field 'editor' is filled with your name
 YAML field 'translator' is filled as needed
-YAML field 'interviewee' is filled as needed, always as a slice with "-"
+YAML field 'interviewee' is filled as needed
 YAML field 'preface' is present if necessary
 YAML field 'params.doi' is filled with a new DOI

--- a/inst/checklists/editor-checklist.csv
+++ b/inst/checklists/editor-checklist.csv
@@ -12,5 +12,6 @@ I ran a spell-check on index.md
 YAML subject tags are ok ("tech notes" for tech notes; "community" for non-staff non-editor)
 YAML field 'editor' is filled with your name
 YAML field 'translator' is filled as needed
+YAML field 'interviewee' is filled as needed, always as a slice with "-"
 YAML field 'preface' is present if necessary
 YAML field 'params.doi' is filled with a new DOI


### PR DESCRIPTION
https://github.com/ropensci/roweb3/pull/1148

Is it annoying to have this item that will rarely need to be checked? Should it live elsewhere?